### PR TITLE
fix(auth): properly handle Azure AD reset password on iOS

### DIFF
--- a/src/services/oidc-authentication-service.ts
+++ b/src/services/oidc-authentication-service.ts
@@ -87,9 +87,9 @@ export class OIDCAuthenticationService implements Authenticator {
       setValue(this.authResultKey, res);
     } catch (err: any) {
       // eslint-disable-next-line
-      console.log('login error:', +err);
-      const message: string = err.message;
-      if (this.options === azureOptions && message !== undefined && message.startsWith('AADB2C90118')) {
+      console.log('login error:', err);
+      const message: string = err.errorMessage;
+      if (this.options === azureOptions && message !== undefined && message.includes('AADB2C90118')) {
         // This is to handle the password reset case for Azure AD and is only applicable to Azure  AD
         // The address you pass back is the custom user flow (policy) endpoint
         const res = await AuthConnect.login(this.provider, {


### PR DESCRIPTION
This fixes a typo when logging out the error of a failed login.
It also adjusts to a new error message format to properly detect and parse the Azure error code when resetting a password.